### PR TITLE
Update for PHP version => 5.5.9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "This package allows you to clear OPcache when running PHP in FPM mode.",
     "type": "package",
     "require": {
-        "php": "^7.0",
+        "php": ">=5.5.9",
         "laravel/framework": "5.*",
         "guzzlehttp/guzzle": "5.3.*"
     },


### PR DESCRIPTION
The package itself does not have any functionality that require PHP 7, so you could reduce the dependency so that the package could be used with PHP version 5.5.9