### PR TITLE
Test whether opcache has been installed

### DIFF
--- a/src/OpcacheClearCommand.php
+++ b/src/OpcacheClearCommand.php
@@ -39,6 +39,10 @@ class OpcacheClearCommand extends Command
      */
     public function handle()
     {
+        if (!function_exists('opcache_reset')) {
+            return $this->line('Opcache not installed');   
+        }
+        
         $client = new Client(['base_uri' => config('app.url', 'http://localhost')]);
         
         $originalToken = config('app.key');


### PR DESCRIPTION
My use case for this is wanting to include this package in our boilerplate deploy process where sometimes a server may not have opcache enabled.  This way, a fatal error isn't produced on servers that lack opcache.